### PR TITLE
Set config file location from the env

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -13,15 +13,18 @@ description: |
 platforms:
   amd64:
 
+environment:
+  HEADSCALE_CONFIG: $SNAP_COMMON/internal/config.yaml
+
 apps:
   headscaled:
-    command: bin/headscale -c $SNAP_COMMON/internal/config.yaml serve
+    command: bin/headscale serve
     daemon: simple
     plugs:
       - network
       - network-bind
   headscale:
-    command: bin/headscale -c $SNAP_COMMON/internal/config.yaml
+    command: bin/headscale
     plugs:
       - network
       - network-bind


### PR DESCRIPTION
This avoids the hacky method of providing the path on the cli args, especially for the `headscale` command,
where the user may add a `-c` argument themselves (duplicate arg).