### PR TITLE
Improve docs for manual config

### DIFF
--- a/docs/config-reference.md
+++ b/docs/config-reference.md
@@ -1,16 +1,21 @@
 # Configuration reference
 
-Example configuration can be found in ../snap/local/default-config.yaml - this is also the default configuration created when the snap is first installed.
-The Headscale service expects to find the configuration file at `/var/snap/headscale/common/config.yaml`.
+Example configuration can be found in [../snap/local/default-config.yaml](../snap/local/default-config.yaml)
+This is also the default configuration created when the snap is first installed.
 
-You are free to edit the configuration file as required.
+See https://headscale.net/stable/ref/configuration/ for upstream documentation on configuration.
+Note that the Headscale service running in the snap expects to find the configuration file at `/var/snap/headscale/common/config.yaml`;
+other paths are not supported.
+
+You are free to edit the configuration file as required, as well as any extra files such as policies or DERP maps.
 Please note that any file paths must be within the standard directories that the strictly confined snap is allowed access to though.
 See https://snapcraft.io/docs/data-locations for more information.
 
-We recommend putting all paths under `/var/snap/headscale/common/`.
+We recommend putting all file paths within `/var/snap/headscale/common/`.
 This is where the config file is found.
-The snap also creates `/var/snap/headscale/common/internal/` as a secure directory (only root accessible),
-where the default config places all sensitive files.
+
+The snap also creates `/var/snap/headscale/common/internal/` as a secure directory (only root accessible) for sensitive data.
+The default config places all sensitive files there.
 
 Headscale must be restarted manually for any changed config to take affect:
 

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -19,6 +19,7 @@ description: |
   The snap provides a headscale service (`headscale serve`) with an initial example configuration, started automatically on install.
   It also provides the `headscale` command to interact with the service.
   You will need to configure the service by editing the configuration file at `/var/snap/headscale/common/config.yaml`.
+  See https://github.com/canonical/headscale-snap/blob/main/docs/config-reference.md for more information on configuration.
 
   **Security**
 
@@ -26,6 +27,11 @@ description: |
 
   * network: general network access.
   * network-bind: required for listening on a network interface.
+
+  The configuration provided by default stores all sensitive data under `/var/snap/headscale/common/internal/`,
+  which is only accessible by the root user.
+  However note that you are free to modify the configuration as you wish;
+  care should be taken to audit the configuration in use.
 
   The snap itself does not directly use any cryptographic functionality.
   Please see upstream docs for information about security of Headscale itself.


### PR DESCRIPTION
This is a follow-up to https://github.com/canonical/headscale-snap/pull/12 , iterating and improving the docs.