### PR TITLE
Update to version 0.24.0

### DIFF
--- a/snap/local/default-config.yaml
+++ b/snap/local/default-config.yaml
@@ -301,15 +301,6 @@ dns:
   #   # you can also put it in one line
   #   - { name: "prometheus.myvpn.example.com", type: "A", value: "100.64.0.3" }
 
-  # DEPRECATED
-  # Use the username as part of the DNS name for nodes, with this option enabled:
-  # node1.username.example.com
-  # while when this is disabled:
-  # node1.example.com
-  # This is a legacy option as Headscale has have this wrongly implemented
-  # while in upstream Tailscale, the username is not included.
-  use_username_in_magic_dns: false
-
 # Unix socket used for the CLI to connect without authentication
 # Note: for production you will want to set this to something like:
 unix_socket: "/var/snap/headscale/common/internal/headscale.sock"

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,6 +1,6 @@
 name: headscale
 base: core24
-version: 0.23.0
+version: 0.24.0
 license: BSD-3-Clause
 grade: stable
 confinement: strict


### PR DESCRIPTION
Please see the following release notes for more information and breaking changes:

- https://github.com/juanfont/headscale/releases/tag/v0.24.0

Especially note the changes relating to OIDC login (a security fix).

`dns.use_username_in_magic_dns` configuration was removed in v0.24.0, so also remove it from the default config here.