### PR TITLE
Bump version

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,6 +1,6 @@
 name: headscale
 base: core24
-version: 0.24.0
+version: 0.24.3
 license: BSD-3-Clause
 grade: stable
 confinement: strict


### PR DESCRIPTION
Latest patch version of 0.24.
Includes some bug fixes.
No breaking changes flagged by upstream.