### PR TITLE
Bump version from 0.24.3 to 0.25.1

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,6 +1,6 @@
 name: headscale
 base: core24
-version: 0.24.3
+version: 0.25.1
 license: BSD-3-Clause
 grade: stable
 confinement: strict


### PR DESCRIPTION
Note that v0.25.0 introduces breaking changes
relating to the authentication flow.
It also drops support for tailscale < 1.62.
Please see https://github.com/juanfont/headscale/releases/tag/v0.25.0 for more information.