### PR TITLE
Bump version from 0.25.1 to 0.26.1

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,6 +1,6 @@
 name: headscale
 base: core24
-version: 0.25.1
+version: 0.26.1
 license: BSD-3-Clause
 grade: stable
 confinement: strict


### PR DESCRIPTION
Note that v0.26.0 introduces breaking changes relateing to route and new policy implementation

Please see 
- https://github.com/juanfont/headscale/releases/tag/v0.26.0 
- https://github.com/juanfont/headscale/releases/tag/v0.26.1